### PR TITLE
allow specifying provider types and endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dcl/l2-scene-utils",
-  "version": "0.0.0-development",
+  "version": "1.0.7-fix-provider-endpoints",
   "description": "A collection of helpers to make it easier to build a Decentraland scene using the SDK.",
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
@@ -8,7 +8,8 @@
   "scripts": {
     "semantic-release": "semantic-release",
     "build": "rollup -c --environment BUILD:production",
-    "build-ecs": "build-ecs"
+    "build-ecs": "build-ecs",
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/src/matic/index.ts
+++ b/src/matic/index.ts
@@ -75,7 +75,14 @@ export async function getContract(
   return { contract, requestManager }
 }
 
-export async function balance(address?: string, network: string = 'mainnet') {
+export async function balance(
+  address?: string,
+  network: string = 'mainnet',
+  providerType: string = 'WebSocketProvider',
+  providerEndpoint: string = 'wss://rpc-mainnet.matic.network',
+  testnetProviderType: string = 'WebSocketProvider',
+  testnetProviderEndpoint: string = 'wss://rpc-mumbai.matic.today'
+) {
   const fromAddress = address || (await getUserAccount())
 
   return Promise.all([
@@ -87,8 +94,8 @@ export async function balance(address?: string, network: string = 'mainnet') {
       addresses[network].l2Token,
       new eth.RequestManager(
         network == 'mainnet'
-          ? new eth.WebSocketProvider('wss://ws-mainnet.matic.network')
-          : new eth.WebSocketProvider('wss://ws-mumbai.matic.today')
+          ? new eth[providerType](providerEndpoint)
+          : new eth[testnetProviderType](testnetProviderEndpoint)
       )
     ).then(async ({ contract }) => {
       const balance = await contract.balanceOf(fromAddress)
@@ -159,7 +166,11 @@ export async function depositMana(amount: number, network: string = 'mainnet') {
 export async function sendMana(
   to: string,
   amount: number,
-  network: string = 'mainnet'
+  network: string = 'mainnet',
+  providerType: string = 'WebSocketProvider',
+  providerEndpoint: string = 'wss://rpc-mainnet.matic.network',
+  testnetProviderType: string = 'WebSocketProvider',
+  testnetProviderEndpoint: string = 'wss://rpc-mumbai.matic.today'
 ) {
   return new Promise(async (resolve, reject) => {
     const fromAddress = await getUserAccount()
@@ -171,8 +182,8 @@ export async function sendMana(
       addresses[network].l2Token,
       new eth.RequestManager(
         network == 'mainnet'
-          ? new eth.WebSocketProvider('wss://ws-mainnet.matic.network')
-          : new eth.WebSocketProvider('wss://ws-mumbai.matic.today')
+        ? new eth[providerType](providerEndpoint)
+        : new eth[testnetProviderType](testnetProviderEndpoint)
       )
     ).then(async ({ contract, requestManager }) => {
       const balance = await contract.balanceOf(fromAddress)


### PR DESCRIPTION
The currently hardcoded RPC endpoints were either erroring out or returning 0 for balance, so now when calling `balance()` or `sendMana()`, we can specify additional arguments to choose between HTTPProvider/WebSocketProvider as well as the provider's endpoint URL.

`balance(myAddress, 'mainnet', 'HTTPProvider', 'https://polygon-rpc.com')`
`sendMana(toAddress, 'mainnet', 'HTTPProvider', 'https://polygon-rpc.com')`